### PR TITLE
Custom for `erc-image-display-func'.

### DIFF
--- a/erc-image.el
+++ b/erc-image.el
@@ -62,8 +62,12 @@
   "Path where to store downloaded images."
   :group 'erc-image)
 
-(defvar erc-image-display-func 'erc-image-insert-inline
-  "Function to use to display the image.")
+(defcustom erc-image-display-func 'erc-image-insert-inline
+  "Function to use to display the image."
+  :group 'erc-image
+  :type '(choice (const :tag "Inline" 'erc-image-insert-inline)
+                 (const :tag "Other buffer" 'erc-image-insert-other-buffer)
+                 function))
 
 (defun erc-image-insert-other-buffer (status file-name marker)
   "Open a new buffer and display file-name image there, scaled."


### PR DESCRIPTION
`erc-image-display-func' is clearly a configuration variable so it deserves a custom.
