### PR TITLE
Scale image to window width or height.

### DIFF
--- a/erc-image.el
+++ b/erc-image.el
@@ -103,7 +103,7 @@
   (let* ((positions (window-inside-absolute-pixel-edges))
          (width (- (nth 2 positions) (nth 0 positions)))
          (height (- (nth 3 positions) (nth 1 positions))))
-    (if (or (fboundp 'imagemagick-types) (not erc-image-inline-rescale-to-window))
+    (if (and (fboundp 'imagemagick-types) erc-image-inline-rescale-to-window)
         (if (> width height)
             (create-image file-name 'imagemagick nil :height height)
           (create-image file-name 'imagemagick nil :width width))


### PR DESCRIPTION
I have often several erc windows open and so they can become quite small (for images). If a image gets inserted inline it is barely viewable if not rescaled.

This commit adds an option to rescale the image to width or height (whatever is smaller) to make it viewable at least in a "preview" sort of way.
