### PR TITLE
Fix "Bad url" errors.

### DIFF
--- a/erc-image.el
+++ b/erc-image.el
@@ -124,13 +124,14 @@ If several regex match prior occurring have higher priority."
     (when url
       (let ((file-name (expand-file-name (md5 url) erc-image-images-path))
             (dl (erc-image-extract-image-url url)))
-        (goto-char (point-max))
-        (url-queue-retrieve dl
-                            erc-image-display-func
-                            (list
-                             file-name
-                             (point-marker))
-                            t)))))
+        (when dl
+          (goto-char (point-max))
+          (url-queue-retrieve dl
+                              erc-image-display-func
+                              (list
+                               file-name
+                               (point-marker))
+                              t))))))
 
 (defun erc-image-extract-image-url (url)
   "Extract the download url using the RE and functions in


### PR DESCRIPTION
`erc-image-extract-image-url` returns `nil` on an URL that is not matched by a regex and makes `url-queue-retrieve` fail with a "Bad url" error.

So check `dl`.
