### PR TITLE
Remove erc from Package-Requires header

### DIFF
--- a/erc-image.el
+++ b/erc-image.el
@@ -7,7 +7,6 @@
 ;; Author: Jon de Andrés Frías <jondeandres@gmail.com>
 ;;         Raimon Grau Cuscó <raimonster@gmail.com>
 ;; Version: 0.9
-;; Package-Requires: ((erc "5.3"))
 ;; Keywords: multimedia
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
New version of ERC (emacs 25) returns "ERC (IRC client for Emacs
25.0.50.1)" as a erc-version and then it isn't possible to install this
package.

Removing this requirement we solve this problem, assuming that ERC is
part of Emacs and we don't need to require it explicitly.