### PR TITLE
Add HTTPS support to Imgur regex.

### DIFF
--- a/erc-image.el
+++ b/erc-image.el
@@ -59,7 +59,7 @@
 (defcustom erc-image-regex-alist
   '(("https?://\\(www\\.\\)?giphy\\.com" .
      erc-image-get-giphy-url)
-    ("http://\\(www\\.\\)?imgur\\.com" .
+    ("https?://\\(www\\.\\)?imgur\\.com" .
      erc-image-get-imgur-url)
     ("\\.\\(png\\|jpg\\|jpeg\\|gif\\|svg\\)$" .
      erc-image-show-url-image))


### PR DESCRIPTION
* erc-image.el: (erc-image-regex-alist): add option HTTPS as a
  possible protocol specifier to the imgur.com regex.