### PR TITLE
Changed the scaling algorithm.

### DIFF
--- a/erc-image.el
+++ b/erc-image.el
@@ -184,7 +184,7 @@ Helper function for erc-image-create-image."
         ;; Figure out in which direction we need to scale
 	(let* ((height-ratio (/ (float height) (cdr dimensions)))
 	       (width-ratio (/ (float width) (car dimensions)))
-	       (extra-shrink-ratio 0.80)
+	       (extra-shrink-ratio erc-image-inline-rescale-window-scale )
 	       (smaller-ratio (if (> width-ratio height-ratio)
 				  height-ratio
 				width-ratio)))

--- a/erc-image.el
+++ b/erc-image.el
@@ -196,6 +196,17 @@ If several regex match prior occurring have higher priority."
       ;; Image is smaller than erc-image-inline-rescale, just give that back
       image)))
 
+(defun erc-image-show-url-image (url)
+  (when (and url (display-graphic-p))
+    (let ((file-name (expand-file-name (md5 url) erc-image-images-path)))
+      (goto-char (point-max))
+      (url-queue-retrieve url
+                          erc-image-display-func
+                          (list
+                           file-name
+                           (point-marker))
+                          t))))
+
 (defun erc-image-show-url ()
   "Calls the proper function to process an URL"
   (goto-char (point-min))

--- a/erc-image.el
+++ b/erc-image.el
@@ -175,8 +175,11 @@ If several regex match prior occurring have higher priority."
       image)))
 
 (defun erc-image--maybe-rescale (image file-name dimensions height width)
-  "Rescale FILE-NAME to have max DIMENSIONS of HEIGHT or WIDTH, or return IMAGE.
-Helper function for erc-image-create-image."
+  "Rescale FILE-NAME to fit within the ERC window. If the image
+ size needs to be reduced it is evenly scaled down so that all
+ dimensions fit within the window. Optionally, it can be scaled
+ down further by setting erc-image-inline-rescale-window-scale."
+
   (let ((imagemagick-p (and (fboundp 'imagemagick-types) 'imagemagick)))
 
     (if (or (> (car dimensions) width)

--- a/erc-image.el
+++ b/erc-image.el
@@ -174,32 +174,24 @@ If several regex match prior occurring have higher priority."
       ;; No rescale
       image)))
 
-(use-package erc-image
-  :after erc
-  :preface 
-  (defun erc-image--maybe-rescale (image file-name dimensions height width)
-    "Rescale FILE-NAME to have max DIMENSIONS of HEIGHT or WIDTH, or return IMAGE.
+(defun erc-image--maybe-rescale (image file-name dimensions height width)
+  "Rescale FILE-NAME to have max DIMENSIONS of HEIGHT or WIDTH, or return IMAGE.
 Helper function for erc-image-create-image."
-    (let ((imagemagick-p (and (fboundp 'imagemagick-types) 'imagemagick)))
+  (let ((imagemagick-p (and (fboundp 'imagemagick-types) 'imagemagick)))
 
-      (if (or (> (car dimensions) width)
-              (> (cdr dimensions) height))
-          ;; Figure out in which direction we need to scale
-	  (let* ((height-ratio (/ (float height) (cdr dimensions)))
-		 (width-ratio (/ (float width) (car dimensions)))
-		 (extra-shrink-ratio 0.80)
-		 (smaller-ratio (if (> width-ratio height-ratio)
-				    height-ratio
-				  width-ratio)))
-		 (create-image file-name imagemagick-p nil
-			       :scale (* smaller-ratio extra-shrink-ratio)))
-	;; Image is smaller than erc-image-inline-rescale, just give that back
-	image)))
-  :config
-  (add-to-list 'erc-modules 'image)
-  (erc-update-modules)
-  :custom
-  (erc-image-inline-rescale 'window))
+    (if (or (> (car dimensions) width)
+            (> (cdr dimensions) height))
+        ;; Figure out in which direction we need to scale
+	(let* ((height-ratio (/ (float height) (cdr dimensions)))
+	       (width-ratio (/ (float width) (car dimensions)))
+	       (extra-shrink-ratio 0.80)
+	       (smaller-ratio (if (> width-ratio height-ratio)
+				  height-ratio
+				width-ratio)))
+	  (create-image file-name imagemagick-p nil
+			:scale (* smaller-ratio extra-shrink-ratio)))
+      ;; Image is smaller than erc-image-inline-rescale, just give that back
+      image)))
 
 (defun erc-image-show-url ()
   "Calls the proper function to process an URL"


### PR DESCRIPTION
The way scaling works when erc-image-inline-rescale is set to 'window does not make sense to me. For instance, imagine my ERC window is 1000x180 and the image I want to rescale is 1920x1080. My understanding of the way it's currently working is that since the width of the image is greater, it would use the width ratio and scale the entire image by a factor of 1/1.92 ~ 0.52. But this would leave the height at ~563, much larger than the height of the window, which seems undesirable.

I've changed it so it calculates the window:image ratio in each dimension and shrinks it by the smaller one. Additionally, I've added a user option to scale it further, in case you don't want the image to consume the entire width or entire height of your window. This should ensure that the image can fit within the window.