### PR TITLE
Get dimensions for erc window instead of currently selected window.

### DIFF
--- a/erc-image.el
+++ b/erc-image.el
@@ -144,7 +144,7 @@ If several regex match prior occurring have higher priority."
 (defun erc-image-create-image (file-name)
   "Create an image suitably scaled according to the setting of
 'ERC-IMAGE-RESCALE."
-  (let* ((positions (window-inside-absolute-pixel-edges))
+  (let* ((positions (window-inside-absolute-pixel-edges (get-buffer-window (current-buffer))))
          (width (- (nth 2 positions) (nth 0 positions)))
          (height (- (nth 3 positions) (nth 1 positions)))
          (image (create-image file-name))

--- a/erc-image.el
+++ b/erc-image.el
@@ -145,7 +145,6 @@ If several regex match prior occurring have higher priority."
   "Given a list of windows displaying the current ERC buffer, return
 the width and height of the window where the image would require
 the most shrinking."
-  (message (format "image height: %s, width: %s" image-height image-width))
   (let ((shrink-ratio most-positive-fixnum)
 	(width -1)
 	(height -1))
@@ -155,11 +154,6 @@ the most shrinking."
 	     (window-height (- (nth 3 positions) (nth 1 positions)))
 	     (cur-shrink-ratio (min (/ (float window-height) image-height)
 				    (/ (float window-width) image-width))))
-	(message (format "Window: %s, width: %s, height: %s, ratio: %s"
-			 window
-			 window-width
-			 window-height
-			 cur-shrink-ratio))
 	(when (> shrink-ratio
 		 cur-shrink-ratio) 
 	  (setq shrink-ratio cur-shrink-ratio
@@ -259,3 +253,4 @@ Helper function for erc-image-create-image."
 
 (provide 'erc-image)
 ;;; erc-image.el ends here
+s


### PR DESCRIPTION
When `erc-image-inline-rescale` is set to `'window` the window the image seems to be being rescaled to is whatever is currently selected. So if I move away from ERC and some other window has focus and I get a message on ERC linking to an image, erc-image seems to use the dimensions of that other window to rescale the image. I believe this PR should force erc-image to use the window associated with the erc buffer.